### PR TITLE
Creds expiresAt fix

### DIFF
--- a/backend/bruno-docs/Credentials/Create Credential.bru
+++ b/backend/bruno-docs/Credentials/Create Credential.bru
@@ -19,7 +19,7 @@ body:json {
   {
     "name": "My SSH Key",
     "type": "ssh_key",
-    "expireAt": "2024-12-31T23:59:59Z",
+    "expiresAt": "2024-12-31T23:59:59Z",
     "secret": {
       "username": "ubuntu",
       "privateKey": "<PRIVATE_KEY_CONTENT>"
@@ -29,5 +29,5 @@ body:json {
 
 docs {
   Add a new SSH credential. The private key will be uploaded to object storage.
-  expireAt is optional and can be null for credentials that don't expire.
+  expiresAt is optional and can be null for credentials that don't expire.
 }

--- a/backend/bruno-docs/Credentials/Update Credential.bru
+++ b/backend/bruno-docs/Credentials/Update Credential.bru
@@ -18,7 +18,7 @@ headers {
 body:json {
   {
     "type": "ssh_key",
-    "expireAt": "2024-12-31T23:59:59Z",
+    "expiresAt": "2024-12-31T23:59:59Z",
     "secret": {
       "username": "ubuntu",
       "privateKey": "<PRIVATE_KEY_CONTENT>"
@@ -28,6 +28,6 @@ body:json {
 
 docs {
   Update an existing SSH credential by ID. 
-  Only type, expireAt and secret could be updated.
+  Only type, expiresAt and secret could be updated.
   Secret will be updated in secret manager.
 }

--- a/backend/internal/model/credential/credential.go
+++ b/backend/internal/model/credential/credential.go
@@ -16,9 +16,9 @@ type Credential struct {
 	Name      *string                `db:"name" json:"name"`
 	Type      *CredentialType        `db:"type" json:"type"`
 	UserID    *string                `db:"user_id" json:"userId"`
-	ExpireAt  *time.Time             `db:"expire_at" json:"expireAt"`
-	CreatedAt *time.Time             `db:"created_at" json:"created_at"`
-	UpdatedAt *time.Time             `db:"updated_at" json:"updated_at"`
+	ExpiresAt *time.Time             `db:"expires_at" json:"expiresAt"`
+	CreatedAt *time.Time             `db:"created_at" json:"createdAt"`
+	UpdatedAt *time.Time             `db:"updated_at" json:"updatedAt"`
 	Secret    map[string]interface{} `json:"secret"`
 }
 

--- a/backend/internal/repository/credential.go
+++ b/backend/internal/repository/credential.go
@@ -87,8 +87,8 @@ func (r *credentialRepository) UpdateCredential(ctx context.Context, c *credenti
 		builder = builder.Set("type", *c.Type)
 	}
 
-	if c.ExpireAt != nil {
-		builder = builder.Set("expire_at", *c.ExpireAt)
+	if c.ExpiresAt != nil {
+		builder = builder.Set("expires_at", *c.ExpiresAt)
 	}
 
 	query, args, err := builder.ToSql()

--- a/backend/internal/repository/sql/credential/createCredential.sql
+++ b/backend/internal/repository/sql/credential/createCredential.sql
@@ -1,4 +1,4 @@
 -- createCredential.sql
-INSERT INTO credentials (name, type, user_id, expire_at) 
-VALUES (:name, :type, :user_id, :expire_at) 
+INSERT INTO credentials (name, type, user_id, expires_at) 
+VALUES (:name, :type, :user_id, :expires_at) 
 RETURNING id; 

--- a/backend/internal/repository/sql/credential/getCredentialById.sql
+++ b/backend/internal/repository/sql/credential/getCredentialById.sql
@@ -1,1 +1,1 @@
-SELECT id, name, type, user_id, expire_at, created_at, updated_at FROM credentials WHERE id = $1; 
+SELECT id, name, type, user_id, expires_at, created_at, updated_at FROM credentials WHERE id = $1; 

--- a/backend/internal/repository/sql/credential/getCredentialsByUserId.sql
+++ b/backend/internal/repository/sql/credential/getCredentialsByUserId.sql
@@ -1,1 +1,1 @@
-SELECT id, name, type, user_id, expire_at, created_at, updated_at FROM credentials WHERE user_id = $1; 
+SELECT id, name, type, user_id, expires_at, created_at, updated_at FROM credentials WHERE user_id = $1; 

--- a/backend/postman-docs/docs.json
+++ b/backend/postman-docs/docs.json
@@ -23,7 +23,7 @@
                             "name": "200 OK",
                             "status": "OK",
                             "code": 200,
-                            "body": "{\n  \"success\": true,\n  \"error\": null,\n  \"data\": {\n    \"id\": 1,\n    \"name\": \"My SSH Key\",\n    \"type\": \"ssh_key\",\n    \"userId\": \"user-uuid\",\n    \"expireAt\": \"2024-12-31T23:59:59Z\",\n    \"created_at\": \"2024-06-01T12:00:00Z\",\n    \"updated_at\": \"2024-06-01T12:00:00Z\",\n    \"secret\": {\n      \"username\": \"ubuntu\",\n      \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n    }\n  }\n}"
+                            "body": "{\n  \"success\": true,\n  \"error\": null,\n  \"data\": {\n    \"id\": 1,\n    \"name\": \"My SSH Key\",\n    \"type\": \"ssh_key\",\n    \"userId\": \"user-uuid\",\n    \"expiresAt\": \"2024-12-31T23:59:59Z\",\n    \"created_at\": \"2024-06-01T12:00:00Z\",\n    \"updated_at\": \"2024-06-01T12:00:00Z\",\n    \"secret\": {\n      \"username\": \"ubuntu\",\n      \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n    }\n  }\n}"
                         }
                     ]
                 },
@@ -42,7 +42,7 @@
                             "name": "200 OK",
                             "status": "OK",
                             "code": 200,
-                            "body": "{\n  \"success\": true,\n  \"error\": null,\n  \"data\": [\n    {\n      \"id\": 1,\n      \"name\": \"My SSH Key 1\",\n      \"type\": \"ssh_key\",\n      \"userId\": \"user-uuid\",\n      \"expireAt\": \"2024-12-31T23:59:59Z\",\n      \"created_at\": \"2024-06-01T12:00:00Z\",\n      \"updated_at\": \"2024-06-01T12:00:00Z\",\n      \"secret\": {\n        \"username\": \"ubuntu\",\n        \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n      }\n    },\n    {\n      \"id\": 2,\n      \"name\": \"My SSH Key 2\",\n      \"type\": \"ssh_key\",\n      \"userId\": \"user-uuid\",\n      \"expireAt\": null,\n      \"created_at\": \"2024-06-01T12:00:00Z\",\n      \"updated_at\": \"2024-06-01T12:00:00Z\",\n      \"secret\": {\n        \"username\": \"ubuntu\",\n        \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n      }\n    }\n  ]\n}"
+                            "body": "{\n  \"success\": true,\n  \"error\": null,\n  \"data\": [\n    {\n      \"id\": 1,\n      \"name\": \"My SSH Key 1\",\n      \"type\": \"ssh_key\",\n      \"userId\": \"user-uuid\",\n      \"expiresAt\": \"2024-12-31T23:59:59Z\",\n      \"created_at\": \"2024-06-01T12:00:00Z\",\n      \"updated_at\": \"2024-06-01T12:00:00Z\",\n      \"secret\": {\n        \"username\": \"ubuntu\",\n        \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n      }\n    },\n    {\n      \"id\": 2,\n      \"name\": \"My SSH Key 2\",\n      \"type\": \"ssh_key\",\n      \"userId\": \"user-uuid\",\n      \"expiresAt\": null,\n      \"created_at\": \"2024-06-01T12:00:00Z\",\n      \"updated_at\": \"2024-06-01T12:00:00Z\",\n      \"secret\": {\n        \"username\": \"ubuntu\",\n        \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n      }\n    }\n  ]\n}"
                         }
                     ]
                 },
@@ -58,7 +58,7 @@
                         "description": "Add a new SSH credential. The private key will be uploaded to object storage.",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"name\": \"My SSH Key\",\n  \"type\": \"ssh_key\",\n  \"expireAt\": \"2024-12-31T23:59:59Z\",\n  \"secret\": {\n    \"username\": \"ubuntu\",\n    \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n  }\n}"
+                            "raw": "{\n  \"name\": \"My SSH Key\",\n  \"type\": \"ssh_key\",\n  \"expiresAt\": \"2024-12-31T23:59:59Z\",\n  \"secret\": {\n    \"username\": \"ubuntu\",\n    \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n  }\n}"
                         }
                     },
                     "response": [
@@ -79,10 +79,10 @@
                             { "key": "Authorization", "value": "Bearer {{authToken}}", "type": "text" }
                         ],
                         "url": { "raw": "{{baseUrl}}/credentials/:id", "host": ["{{baseUrl}}"], "path": ["credentials", ":id"] },
-                        "description": "Update an existing SSH credential by ID. Only type, expireAt and secret could be updated. Secret will be updated in secret manager.",
+                        "description": "Update an existing SSH credential by ID. Only type, expiresAt and secret could be updated. Secret will be updated in secret manager.",
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n  \"type\": \"ssh_key\",\n  \"expireAt\": \"2024-12-31T23:59:59Z\",\n  \"secret\": {\n    \"anyKey\": \"ValuePair\",\n    \"username\": \"ubuntu\",\n    \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n  }\n}"
+                            "raw": "{\n  \"type\": \"ssh_key\",\n  \"expiresAt\": \"2024-12-31T23:59:59Z\",\n  \"secret\": {\n    \"anyKey\": \"ValuePair\",\n    \"username\": \"ubuntu\",\n    \"privateKey\": \"<PRIVATE_KEY_CONTENT>\"\n  }\n}"
                         }
                     },
                     "response": [

--- a/backend/sql/init.sql
+++ b/backend/sql/init.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS credentials (
     name TEXT NOT NULL,
     type credential_type NOT NULL,
     user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-    expire_at TIMESTAMP,
+    expires_at TIMESTAMP,
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),
     UNIQUE(user_id, name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation and examples to use "expiresAt" instead of "expireAt" for credential expiration timestamps.
  * Adjusted descriptive text and request/response examples to reflect the new field name.

* **Bug Fixes**
  * Corrected field and column names related to credential expiration from "expireAt" to "expiresAt" across the application for consistency.

* **Refactor**
  * Standardized JSON field names to camelCase (e.g., "createdAt", "updatedAt") for improved consistency in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->