### PR TITLE
Load existing blueprint

### DIFF
--- a/frontend/app/dashboard/infrastructure/create/page.tsx
+++ b/frontend/app/dashboard/infrastructure/create/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import React, { useState, useCallback, useMemo, useRef, useEffect, Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import {
 	ReactFlow,
@@ -61,12 +61,27 @@ interface InfrastructureBuilderState {
 }
 
 
-function InfrastructureBuilder() {
+// Component that uses useSearchParams - needs to be wrapped in Suspense
+function InfrastructureBuilderWithParams() {
+	const searchParams = useSearchParams()
+	return <InfrastructureBuilder searchParams={searchParams} />
+}
+
+// Loading component for Suspense fallback
+function InfrastructureBuilderLoading() {
+	return (
+		<div className='h-screen gradient-bg noise-overlay flex items-center justify-center'>
+			<div className='text-center'>
+				<div className='animate-spin rounded-full h-12 w-12 border-b-2 border-cyan-400 mx-auto mb-4'></div>
+				<p className='text-white'>Loading...</p>
+			</div>
+		</div>
+	)
+}
+
+function InfrastructureBuilder({ searchParams }: { searchParams: URLSearchParams }) {
 	const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
 	const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
-	
-	// Get URL search parameters
-	const searchParams = useSearchParams()
 	
 	// Fetch components from API
 	const { components, isLoading, error } = useComponents()
@@ -858,7 +873,9 @@ function InfrastructureBuilder() {
 export default function CreateInfraPage() {
 	return (
 		<ReactFlowProvider>
-			<InfrastructureBuilder />
+			<Suspense fallback={<InfrastructureBuilderLoading />}>
+				<InfrastructureBuilderWithParams />
+			</Suspense>
 		</ReactFlowProvider>
 	)
 }

--- a/frontend/app/dashboard/infrastructure/create/page.tsx
+++ b/frontend/app/dashboard/infrastructure/create/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
 import {
 	ReactFlow,
 	MiniMap,
@@ -26,9 +27,9 @@ import { EmptyState } from '@/components/infrastructure/empty-state'
 import { ViewPlanModal } from '@/components/dashboard/ViewPlanModal'
 import { BlueprintMetadataModal } from '@/components/dashboard/BlueprintMetadataModal'
 import { Button } from '@/components/ui/button'
-import { Edit } from 'lucide-react'
+import { Edit, FileCode } from 'lucide-react'
 import { buildComponentCategories, getNodeTypes } from '@/lib/infrastructure-components'
-import { useBlueprints } from '@/hooks/useBlueprint'
+import { useBlueprints, type BlueprintWithComponents, type BlueprintComponent } from '@/hooks/useBlueprint'
 import { useComponents } from '@/hooks/useComponents'
 import { DashboardFooter } from '@/components/dashboard-footer'
 
@@ -59,9 +60,13 @@ interface InfrastructureBuilderState {
 	isSaving: boolean
 }
 
+
 function InfrastructureBuilder() {
 	const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
 	const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
+	
+	// Get URL search parameters
+	const searchParams = useSearchParams()
 	
 	// Fetch components from API
 	const { components, isLoading, error } = useComponents()
@@ -85,20 +90,47 @@ function InfrastructureBuilder() {
 		return getNodeTypes(components)
 	}, [components, isLoading, error])
 	
+	// Decode blueprint data from URL parameters
+	const getBlueprintDataFromUrl = useCallback((): BlueprintWithComponents | null => {
+		const encodedData = searchParams.get('data')
+		if (encodedData) {
+			try {
+				const decodedData = JSON.parse(atob(encodedData)) as BlueprintWithComponents
+				console.log('Decoded Blueprint Data:', decodedData)
+				return decodedData
+			} catch (error) {
+				console.error('Failed to decode blueprint data:', error)
+				return null
+			}
+		}
+		return null
+	}, [searchParams])
+
+	// Store decoded blueprint data
+	const [blueprintData, setBlueprintData] = useState<BlueprintWithComponents | null>(() => {
+		return getBlueprintDataFromUrl()
+	})
+
+	// Store component loading errors
+	const [componentErrors, setComponentErrors] = useState<string[]>([])
+
 	// Initialize expanded categories when components are loaded
-	const [state, setState] = useState<InfrastructureBuilderState>({
-		agentConnected: true,
-		sidebarCollapsed: false,
-		mobileMenuOpen: false,
-		searchTerm: '',
-		expandedCategories: {},
-		draggedNodeType: null,
-		isViewPlanOpen: false,
-		generatedPlan: '',
-		configName: '',
-		configDescription: '',
-		blueprintId: undefined,
-		isSaving: false,
+	const [state, setState] = useState<InfrastructureBuilderState>(() => {
+		const decodedBlueprintData = getBlueprintDataFromUrl()
+		return {
+			agentConnected: true,
+			sidebarCollapsed: false,
+			mobileMenuOpen: false,
+			searchTerm: '',
+			expandedCategories: {},
+			draggedNodeType: null,
+			isViewPlanOpen: false,
+			generatedPlan: '',
+			configName: decodedBlueprintData?.name || searchParams.get('name') || '',
+			configDescription: decodedBlueprintData?.description || searchParams.get('description') || '',
+			blueprintId: decodedBlueprintData?.id?.toString() || searchParams.get('blueprintId') || undefined,
+			isSaving: false,
+		}
 	})
 	
 	// Update expanded categories when componentCategories change
@@ -111,6 +143,93 @@ function InfrastructureBuilder() {
 			}))
 		}
 	}, [componentCategories])
+
+	// Convert BlueprintComponent to React Flow Node
+	const convertBlueprintComponentToNode = useCallback((blueprintComponent: BlueprintComponent, index: number): Node | null => {
+		// Get the extended component with visual properties
+		const extendedComponents = getNodeTypes(components)
+		const componentDef = extendedComponents.find(comp => comp.id === blueprintComponent.componentId)
+		
+		if (!componentDef) {
+			const errorMessage = `Component with ID ${blueprintComponent.componentId} not found`
+			console.warn(errorMessage)
+			setComponentErrors(prev => [...prev, errorMessage])
+			return null
+		}
+
+		// Convert parameters array to object
+		const parameters = blueprintComponent.parameters.reduce((acc, param) => {
+			acc[param.name] = param.value
+			return acc
+		}, {} as Record<string, any>)
+
+		return {
+			id: `component-${blueprintComponent.id}`,
+			type: 'customNode',
+			position: { x: 100 + (index * 400), y: 100 }, // Increased distance between nodes
+			data: {
+				id: componentDef.id,
+				label: componentDef.displayName,
+				nodeType: componentDef.name,
+				icon: componentDef.icon,
+				color: componentDef.color,
+				bgColor: componentDef.bgColor,
+				borderColor: componentDef.borderColor,
+				components: components,
+				parameters: parameters
+			},
+		}
+	}, [components])
+
+	// Log blueprint components when available
+	useEffect(() => {
+		if (blueprintData?.components) {
+			console.log('Blueprint Components from URL:', blueprintData.components)
+		}
+	}, [blueprintData])
+
+	// Load blueprint components as nodes when both blueprint data and components are available
+	useEffect(() => {
+		if (blueprintData?.components && components.length > 0 && !isLoading) {
+			console.log('Loading blueprint components as nodes...')
+			
+			// Clear previous errors
+			setComponentErrors([])
+			
+			// Convert blueprint components to React Flow nodes
+			const nodesFromBlueprint = blueprintData.components
+				.map((blueprintComponent, index) => 
+					convertBlueprintComponentToNode(blueprintComponent, index)
+				)
+				.filter((node): node is Node => node !== null) // Filter out null nodes
+			
+			// Create edges based on position (connect nodes in sequence)
+			const edgesFromBlueprint: Edge[] = []
+			for (let i = 0; i < nodesFromBlueprint.length - 1; i++) {
+				edgesFromBlueprint.push({
+					id: `edge-${nodesFromBlueprint[i].id}-${nodesFromBlueprint[i + 1].id}`,
+					source: nodesFromBlueprint[i].id,
+					target: nodesFromBlueprint[i + 1].id,
+					type: 'smoothstep',
+					style: {
+						stroke: '#06b6d4',
+						strokeWidth: 2,
+					},
+					markerEnd: {
+						type: MarkerType.ArrowClosed,
+						color: '#06b6d4',
+					},
+				})
+			}
+			
+			// Set the nodes and edges
+			setNodes(nodesFromBlueprint)
+			setEdges(edgesFromBlueprint)
+			
+			console.log('Loaded nodes:', nodesFromBlueprint)
+			console.log('Loaded edges:', edgesFromBlueprint)
+		}
+	}, [blueprintData, components, isLoading, convertBlueprintComponentToNode, setNodes, setEdges])
 
 	const reactFlowWrapper = useRef<HTMLDivElement>(null)
 	const { screenToFlowPosition } = useReactFlow()
@@ -568,8 +687,16 @@ function InfrastructureBuilder() {
 								variant='ghost'
 								size='sm'
 								className='p-1 h-auto text-gray-400 hover:text-cyan-400'
-								aria-label='Edit configuration metadata'
-								title='Edit configuration metadata'
+								aria-label={
+									state.blueprintId
+										? 'Edit configuration metadata'
+										: 'Create configuration metadata'
+								}
+								title={
+									state.blueprintId
+										? 'Edit configuration metadata'
+										: 'Create configuration metadata'
+								}
 							>
 								<Edit className='h-3 w-3' />
 							</Button>
@@ -577,6 +704,37 @@ function InfrastructureBuilder() {
 					/>
 				}
 			/>
+
+			{/* Component Errors */}
+			{componentErrors.length > 0 && (
+				<div className='glass-card border-red-500/20 bg-red-500/5 mx-4 mb-4'>
+					<div className='flex items-start gap-3'>
+						<div className='p-2 rounded-full bg-red-500/20'>
+							<FileCode className='h-5 w-5 text-red-400' />
+						</div>
+						<div className='flex-1'>
+							<h3 className='text-lg font-semibold text-red-400 mb-2'>
+								Component Loading Errors
+							</h3>
+							<div className='space-y-1'>
+								{componentErrors.map((error, index) => (
+									<p key={index} className='text-red-300 text-sm'>
+										• {error}
+									</p>
+								))}
+							</div>
+						</div>
+						<Button
+							variant='ghost'
+							size='sm'
+							onClick={() => setComponentErrors([])}
+							className='text-red-400 hover:text-red-300 hover:bg-red-500/10'
+						>
+							×
+						</Button>
+					</div>
+				</div>
+			)}
 
 			{/* Main Content Area */}
 			<div className='flex flex-1 overflow-hidden relative h-full'>

--- a/frontend/app/dashboard/infrastructure/page.tsx
+++ b/frontend/app/dashboard/infrastructure/page.tsx
@@ -101,6 +101,7 @@ export default function InfrastructurePage() {
 			const params = new URLSearchParams({
 				data: encodedData
 			})
+			// @TODO - using query param for now - this can lead to url length limit issues
 			router.push(`/dashboard/infrastructure/create?${params.toString()}`)
 		} catch (error) {
 			console.error('Failed to fetch blueprint components:', error)

--- a/frontend/hooks/useBlueprint.ts
+++ b/frontend/hooks/useBlueprint.ts
@@ -12,6 +12,37 @@ export interface Blueprint {
   updatedAt: string
 }
 
+// Blueprint Component interface based on API structure
+export interface BlueprintComponent {
+  id: number
+  blueprintId: number
+  componentId: number
+  position: number
+  parameters: Array<{
+    id: string
+    value: string
+    name: string
+  }>
+  createdAt: string
+  updatedAt: string
+}
+
+// Blueprint data with components for passing through URL
+export interface BlueprintWithComponents extends Blueprint {
+  components: BlueprintComponent[]
+}
+
+// Interface for updating blueprint components (simplified structure for API calls)
+export interface BlueprintComponentUpdate {
+  componentId: number
+  position: number
+  parameters: Array<{
+    id: string
+    value: string
+    name: string
+  }>
+}
+
 // Function to get a random emoji for blueprints
 const getRandomEmoji = (): string => {
   const emojis = [
@@ -176,15 +207,7 @@ export function useBlueprints() {
   }, [])
 
   // Update blueprint components
-  const updateBlueprintComponents = useCallback(async (blueprintId: number, components: Array<{
-    componentId: number
-    position: number
-    parameters: Array<{
-      id: string
-      value: string
-      name: string
-    }>
-  }>) => {
+  const updateBlueprintComponents = useCallback(async (blueprintId: number, components: BlueprintComponentUpdate[]) => {
     try {
       setError(null)
       
@@ -205,6 +228,20 @@ export function useBlueprints() {
     return "Plan generated"
   }, [])
 
+  // Get blueprint components
+  const getBlueprintComponents = useCallback(async (blueprintId: number): Promise<BlueprintComponent[]> => {
+    try {
+      logger.info(`Fetching components for blueprint: ${blueprintId}`)
+      const response = await httpClient.get(`/blueprint/${blueprintId}/components`)
+      logger.info(`Successfully fetched blueprint components for blueprint: ${blueprintId}`)
+      return response.data as BlueprintComponent[]
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch blueprint components'
+      logger.error('Error fetching blueprint components:', err)
+      throw new Error(errorMessage)
+    }
+  }, [])
+
   return {
     blueprints,
     loading,
@@ -214,6 +251,7 @@ export function useBlueprints() {
     updateBlueprintComponents,
     deleteBlueprint,
     generatePlan,
+    getBlueprintComponents,
     getEmojiForBlueprint,
     refreshBlueprints: fetchBlueprints
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Open the create page directly from a Blueprint card with preloaded blueprint and components.
  - URL-based prefill: share a link that auto-loads configuration and renders nodes/edges in the diagram.

- UI/UX
  - Blueprint cards are now clickable; Plan/Edit/Delete buttons no longer trigger card clicks.
  - Clear error handling for component loading: inline banner on Infrastructure and an in-page “Component Loading Errors” panel on Create, both dismissible.
  - Save/Config button label and tooltip now reflect Edit vs Create states.

- Bug Fixes
  - Prevent accidental navigation when using card action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->